### PR TITLE
Fix filetype option when filetype is set as cpp

### DIFF
--- a/autoload/auto_ctags.vim
+++ b/autoload/auto_ctags.vim
@@ -70,7 +70,9 @@ endfunction
 function! auto_ctags#ctags_cmd_opt()
   let s:opt = g:auto_ctags_tags_args
   if g:auto_ctags_filetype_mode > 0
-      if &filetype !=# ''
+      if &filetype ==# 'cpp'
+        let s:opt = s:opt.' --languages=c++'
+      elseif &filetype !=# ''
         let s:opt = s:opt.' --languages='.&filetype
       endif
   endif


### PR DESCRIPTION
ctagsの-languagesオプションでcppファイルを指定する場合は，なぜか'cpp'はダメみたいです．
```bash
ctags -R --languages=cpp  # Unknown language "cpp"
ctags -R --languages=c++  # OK
```
なのでauto_ctags_filetype_modeを有効にした場合，cppファイルのtagが生成されません．
修正よろしくお願い致します．