### PR TITLE
add option g:auto_ctags_search_recursively

### DIFF
--- a/autoload/auto_ctags.vim
+++ b/autoload/auto_ctags.vim
@@ -38,12 +38,22 @@ if !exists("g:auto_ctags_filetype_mode")
   let g:auto_ctags_filetype_mode = 0
 endif
 
+if !exists("g:auto_ctags_search_recursively")
+  let g:auto_ctags_search_recursively = 0
+endif
+
 "------------------------
 " function
 "------------------------
 function! auto_ctags#ctags_path()
   let s:path = ''
   for s:directory in g:auto_ctags_directory_list
+    if g:auto_ctags_search_recursively > 0
+      let s:dirs = finddir(s:directory, escape(expand('<afile>:p:h'), ' ') . ';', -1)
+      if !empty(s:dirs)
+        let s:directory = s:dirs[0]
+      endif
+    endif
     if isdirectory(s:directory)
       let s:tags_name = g:auto_ctags_tags_name
       if g:auto_ctags_filetype_mode > 0


### PR DESCRIPTION
I want to search ctag directories in `g:auto_ctags_directory_list` recursively.
To realize this feature, I added an option `g:auto_ctags_search_recursively`.

If `g:auto_ctags_search_recursively` is not set or set as 0, it doesn't affect original behavior.
If `g:auto_ctags_search_recursively` is set larger than 0, it searches `g:auto_ctags_directory_list` recursively.

For example, assume following directory structure.
```
|-.git/
|-src/
  |-main.c
```
And `.vimrc` is like below.
```vim
g:auto_ctags_directory_list = [.git]
g:auto_ctags_search_recursively = 1
```

Then, even if you open main.c on `src/` directory, ctags file is created in `.git/`.
