### PR TITLE
DockerブランチによるDockerfile確認

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,18 @@ rvm:
 dist: xenial
 services:
   - xvfb
+  - docker
 before_install:
   - sudo add-apt-repository ppa:jonathonf/vim -y
   - sudo apt update
   - sudo apt install vim-gtk3
   - sudo apt install exuberant-ctags
+jobs:
+  include:
+    - stage: rake
+      script: bundle exec rake
+    - stage: docker
+      script: sh ./run-test.sh
 before_script:
   - which vim
   - vim --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,6 @@ dist: xenial
 services:
   - xvfb
   - docker
-before_install:
-  - sudo add-apt-repository ppa:jonathonf/vim -y
-  - sudo apt update
-  - sudo apt install vim-gtk3
-  - sudo apt install exuberant-ctags
 stages:
   - name: rake
     if: branch != docker
@@ -18,6 +13,11 @@ stages:
 jobs:
   include:
     - stage: rake
+      before_install:
+        - sudo add-apt-repository ppa:jonathonf/vim -y
+        - sudo apt update
+        - sudo apt install vim-gtk3
+        - sudo apt install exuberant-ctags
       script: bundle exec rake
     - stage: docker
       script: sh ./run-test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,11 @@ jobs:
         - sudo apt update
         - sudo apt install vim-gtk3
         - sudo apt install exuberant-ctags
+      before_script:
+        - which vim
+        - vim --version
+        - ctags --version
+        - cat Gemfile.lock
       script: bundle exec rake
     - stage: docker
       script: sh ./run-test.sh
-before_script:
-  - which vim
-  - vim --version
-  - ctags --version
-  - cat Gemfile.lock
-  - "export DISPLAY=:99.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ before_install:
   - sudo apt update
   - sudo apt install vim-gtk3
   - sudo apt install exuberant-ctags
+stages:
+  - name: rake
+    if: branch != docker
+  - name: docker
+    if: branch = docker
 jobs:
   include:
     - stage: rake


### PR DESCRIPTION
先日のPRではDockerfileが不適切でしたので、再発防止に以下のような仕組みを提案します。

* dockerブランチではDockerでテスト実施
* それ以外はrakeでテスト実施
するようにする

なお、DISPLAY環境変数はxvfbサービス実行時に設定してもらえるようなので削除しました。
別件で確認後、このリポジトリのforkのテストで確認しています。( [tsuyoshicho/auto\-ctags\.vim \- Travis CI](https://travis-ci.org/tsuyoshicho/auto-ctags.vim/branches) )

手元でテストの実行(のためのDockerの実行)が可能であるべきですが、Dockerファイルを修正したら、dockerブランチに反映すれば確実に確認できる、程度には使えるかと思います。