### PR TITLE
add configuration to suppress warn msgs repeatedly shown

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Create the filetype tags `--languages=` option mode, default `0`
 
     let g:auto_ctags_filetype_mode = 1
 
+Show all warning messages only once, default `0`
+
+    let g:auto_ctags_warn_once = 1
+
 ## Testing
 
 Please install `docker`

--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ Create the filetype tags `--languages=` option mode, default `0`
 
     let g:auto_ctags_filetype_mode = 1
 
+Set a valid tags option by calling `:setlocal tags^=<tags file name>` per buffers
+
+    :CtagsSetTagsOption
+
+Call automatically `:CtagsSetTagsOption` when BufNewFile and BufRead are triggered, default `0`
+
+    let g:auto_ctags_set_tags_option = 1
+
 Show all warning messages only once, default `0`
 
     let g:auto_ctags_warn_once = 1

--- a/autoload/auto_ctags.vim
+++ b/autoload/auto_ctags.vim
@@ -47,6 +47,10 @@ if !exists("g:auto_ctags_filetype_mode")
   let g:auto_ctags_filetype_mode = 0
 endif
 
+if !exists("g:auto_ctags_set_tags_option")
+  let g:auto_ctags_set_tags_option = 0
+endif
+
 if !exists("g:auto_ctags_search_recursively")
   let g:auto_ctags_search_recursively = 0
 endif
@@ -191,6 +195,13 @@ function! auto_ctags#ctags(recreate)
 
   if a:recreate > 0
     redraw!
+  endif
+endfunction
+
+function! auto_ctags#set_tags_option()
+  let tag_path = auto_ctags#ctags_path()
+  if tag_path != '' && stridx(&tags, tag_path) == -1
+      execute 'setlocal tags^='.tag_path
   endif
 endfunction
 

--- a/autoload/auto_ctags.vim
+++ b/autoload/auto_ctags.vim
@@ -55,6 +55,11 @@ if !exists("g:auto_ctags_absolute_path")
   let g:auto_ctags_absolute_path = 0
 endif
 
+let g:auto_ctags_warn_msgs = {}
+if !exists("g:auto_ctags_warn_once")
+  let g:auto_ctags_warn_once = 0
+endif
+
 " lockfile set
 let s:lockfiles = s:Set.set()
 
@@ -190,11 +195,18 @@ function! auto_ctags#ctags(recreate)
 endfunction
 
 function! s:warn(msg)
+  if g:auto_ctags_warn_once > 0
+    if has_key(g:auto_ctags_warn_msgs, a:msg)
+      " this msg is already shown, so ignore
+      return
+    else
+      let g:auto_ctags_warn_msgs[a:msg] = 1
+    endif
+  endif
   echohl WarningMsg
   echo 'auto_ctags.vim:' a:msg
   echohl None
 endfunction
-
 
 " after care:lockfile delete at vim exit
 function! s:lockfile_del_atquit()

--- a/plugin/auto_ctags.vim
+++ b/plugin/auto_ctags.vim
@@ -14,9 +14,13 @@ set cpo&vim
 augroup auto_ctags
   autocmd!
   autocmd BufWritePost * call auto_ctags#ctags(0)
+  if g:auto_ctags_set_tags_option > 0
+    autocmd BufNewFile,BufRead * call auto_ctags#set_tags_option()
+  endif
 augroup END
 
 command! Ctags call auto_ctags#ctags(1)
+command! CtagsSetTagsOption call auto_ctags#set_tags_option()
 
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
If a valid ctags_directory_list doesn't exist,
a warning message like 'Tags path not exists.' is repeatedly shown.

However, for instance, in editting files not related to ctags like
config files, such warnings are annoying.

So, I added the configuration to suppress warn msgs repeatedly shown.
If this configuration is enabled, all warning message are shown once.

By setting 'let g:auto_ctags_warn_once = 1' in your vimrc,
this configuration can be enabled.

Signed-off-by: KZYSAKYM <akiyama.kazuyoshi.64w@gmail.com>