### PR TITLE
Move `g:auto_ctags_set_tags_option` declaration to plugin/auto_ctags.vim

### DIFF
--- a/autoload/auto_ctags.vim
+++ b/autoload/auto_ctags.vim
@@ -47,10 +47,6 @@ if !exists("g:auto_ctags_filetype_mode")
   let g:auto_ctags_filetype_mode = 0
 endif
 
-if !exists("g:auto_ctags_set_tags_option")
-  let g:auto_ctags_set_tags_option = 0
-endif
-
 if !exists("g:auto_ctags_search_recursively")
   let g:auto_ctags_search_recursively = 0
 endif

--- a/plugin/auto_ctags.vim
+++ b/plugin/auto_ctags.vim
@@ -11,6 +11,10 @@ let g:loaded_auto_ctags = 1
 let s:save_cpo = &cpo
 set cpo&vim
 
+if !exists("g:auto_ctags_set_tags_option")
+  let g:auto_ctags_set_tags_option = 0
+endif
+
 augroup auto_ctags
   autocmd!
   autocmd BufWritePost * call auto_ctags#ctags(0)


### PR DESCRIPTION
When I launched Vim, I got error messages like below.

```
Error detected while processing /path/to/plugin/auto-ctags.vim/plugin/auto_ctags.vim:
line   17:
E121: Undefined variable: g:auto_ctags_set_tags_option
```

It is because `g:auto_ctags_set_tags_option` was read before autoload/auto_ctags.vim was loaded (`g:auto_ctags_set_tags_option` was declared in autoload/auto_ctags.vim).
autoload/auto_ctags.vim is loaded when `auto_ctags#xxx()` function is called.

So I moved `g:auto_ctags_set_tags_option` declaration to plugin/auto_ctags.vim.