### PR TITLE
Remove trailing path separator from tags directory

### DIFF
--- a/autoload/auto_ctags.vim
+++ b/autoload/auto_ctags.vim
@@ -72,7 +72,7 @@ function! auto_ctags#ctags_path()
     if g:auto_ctags_search_recursively > 0
       let dirs = finddir(directory, escape(expand('<afile>:p:h'), ' ') . ';', -1)
       if !empty(dirs)
-        let directory = fnamemodify(dirs[0], ':p')
+        let directory = s:Path.remove_last_separator(fnamemodify(dirs[0], ':p'))
       endif
     endif
     if isdirectory(directory)


### PR DESCRIPTION
Before this patch, setting `g:auto_ctags_search_recursively = 1` resulted in a tags path of the form `/path/to//tags` (note the double slash at the end). The extra path separator confuses `exuberant-ctags` and results in wrong relative paths in the tags file.

Note: I was not able to run the tests, and I apologize. I tried installing docker on my machine but I am having trouble with my package server. I hope that is not a concern.